### PR TITLE
adding BridgedBalance and BridgedSupply

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,14 +36,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # TODO:
-    # there has an issue of rust 2022-01-15 nightly version toolchain
-    # https://github.com/taiki-e/cargo-llvm-cov/issues/128
-    # so do a work around here to tag older nightly version
     - uses: actions-rs/toolchain@v1
       with:
           profile: minimal
-          toolchain: nightly-2022-01-14
+          toolchain: nightly
           override: true
           components: llvm-tools-preview
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,17 @@ jobs:
         toolchain: stable
         components: rustfmt, clippy 
 
+    - name: Using cache to speed up
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
     - name: Check Formatting
       run: cargo fmt --all -- --check 
 
@@ -47,6 +58,17 @@ jobs:
       uses: taiki-e/install-action@v1
       with:
         tool: cargo-llvm-cov
+
+    - name: Using cache to speed up
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Generate code coverage
       run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-stable-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Check Formatting
       run: cargo fmt --all -- --check 
@@ -68,7 +68,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-nightly-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Generate code coverage
       run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,17 @@ jobs:
         toolchain: stable
         components: rustfmt, clippy 
 
+    - name: Using cache to speed up
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
     - name: Check Formatting
       run: cargo fmt --all -- --check 
 
@@ -60,6 +71,17 @@ jobs:
           target: x86_64-unknown-linux-musl
           override: true
           profile: minimal
+
+      - name: Using cache to speed up
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       # I used a tricky way to do the building,
       # since cargo deb will building out 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-stable-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Check Formatting
       run: cargo fmt --all -- --check 
@@ -81,7 +81,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-stable-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       # I used a tricky way to do the building,
       # since cargo deb will building out 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "findora-exporter"
-version = "1.1.1"
+version = "1.2.0"
 authors = ["tommady <tommady@users.noreply.github.com>"]
 edition = "2021"
 readme = "README.md"
@@ -45,6 +45,7 @@ the deb package will try to install
 1. the findora-exporter as a systemd service
 2. put the binary under /usr/local/bin/ folder
 3. expecting a config file at /etc/prometheus/findora_exporter_config.json
+4. expecting a user named ubuntu
 """
 
 [package.metadata.deb.systemd-units]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This exporter has below custom metrics right now!
 | NetworkFunctional | subtraction of seconds of the latest block time with the current time |
 | TotalCountOfValidators | the total number of validators from the consensus network |
 | TotalBalanceOfRelayers | the total balance value of relayers from the specific bridge ( this metric displays with 8 digits as the fractional part so need to divide the metric value by 10 to the power of 8 ) |
+| BridgedBalance | the token balance of reserving safe on source chain |
+| BridgedSupply | the token supply total minted on the destination chain |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ After that
 * An executable binary will be put into `/usr/local/bin/findora-exporter`
 * A systemd `findora-exporter.service` will be loaded
 * expecting a config file at `/etc/prometheus/findora_exporter_config.json`
+* expecting a user named `ubuntu`
 
 ```bash
 $ systemctl status findora-exporter.service

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ This exporter has below custom metrics right now!
 | NetworkFunctional | subtraction of seconds of the latest block time with the current time |
 | TotalCountOfValidators | the total number of validators from the consensus network |
 | TotalBalanceOfRelayers | the total balance value of relayers from the specific bridge ( this metric displays with 8 digits as the fractional part so need to divide the metric value by 10 to the power of 8 ) |
-| BridgedBalance | the token balance of reserving safe on source chain |
-| BridgedSupply | the token supply total minted on the destination chain |
+| BridgedBalance | the token balance of reserving safe on source chain ( this metric displays with 8 digits as the fractional part so need to divide the metric value by 10 to the power of 8 ) |
+| BridgedSupply | the token supply total minted on the destination chain ( this metric displays with 8 digits as the fractional part so need to divide the metric value by 10 to the power of 8 ) |
 
 ## Installation
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,7 +70,7 @@ pub(crate) enum TaskName {
     TotalCountOfValidators,
     TotalBalanceOfRelayers,
     BridgedBalance,
-    //    BridgedSupply,
+    BridgedSupply,
 }
 
 impl Default for TaskName {
@@ -87,6 +87,9 @@ pub(crate) enum ExtraOpts {
     },
     BridgedBalance {
         erc20handler_address: String,
+        token_address: String,
+    },
+    BridgedSupply {
         token_address: String,
     },
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,6 +69,8 @@ pub(crate) enum TaskName {
     NetworkFunctional,
     TotalCountOfValidators,
     TotalBalanceOfRelayers,
+    BridgedBalance,
+    //    BridgedSupply,
 }
 
 impl Default for TaskName {
@@ -78,8 +80,15 @@ impl Default for TaskName {
 }
 
 #[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(untagged)]
 pub(crate) enum ExtraOpts {
-    BridgeAddress(String),
+    TotalBalanceOfRelayers {
+        bridge_address: String,
+    },
+    BridgedBalance {
+        erc20handler_address: String,
+        token_address: String,
+    },
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]

--- a/src/crawler.rs
+++ b/src/crawler.rs
@@ -54,6 +54,9 @@ where
                     "get_relayer_balance",
                     crate::tasks::total_balance_of_relayers,
                 ),
+                TaskName::BridgedBalance => {
+                    Task::new("bridged_balance", crate::tasks::bridged_balance)
+                }
             };
 
             workers.push(Arc::new(RwLock::new(Worker::new(target, metric, task))));

--- a/src/crawler.rs
+++ b/src/crawler.rs
@@ -57,6 +57,9 @@ where
                 TaskName::BridgedBalance => {
                     Task::new("bridged_balance", crate::tasks::bridged_balance)
                 }
+                TaskName::BridgedSupply => {
+                    Task::new("bridged_supply", crate::tasks::bridged_supply)
+                }
             };
 
             workers.push(Arc::new(RwLock::new(Worker::new(target, metric, task))));

--- a/src/crawler.rs
+++ b/src/crawler.rs
@@ -51,7 +51,7 @@ where
                     crate::tasks::total_count_of_validators,
                 ),
                 TaskName::TotalBalanceOfRelayers => Task::new(
-                    "get_relayer_balance",
+                    "total_balance_of_relayers",
                     crate::tasks::total_balance_of_relayers,
                 ),
                 TaskName::BridgedBalance => {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -118,6 +118,11 @@ where
                 "the token balance of reserving safe on source chain",
             )
             .context("new bridged_balance failed")?,
+            TaskName::BridgedSupply => GenericGauge::new(
+                "bridged_supply",
+                "the token supply total minted on the destination chain",
+            )
+            .context("new bridged_supply failed")?,
         };
 
         registry

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -113,6 +113,11 @@ where
                 "the total balance of relayers from the specific bridge",
             )
             .context("new total_balance_of_relayers failed")?,
+            TaskName::BridgedBalance => GenericGauge::new(
+                "bridged_balance",
+                "the token balance of reserving safe on source chain",
+            )
+            .context("new bridged_balance failed")?,
         };
 
         registry

--- a/src/tasks/bridged_balance.rs
+++ b/src/tasks/bridged_balance.rs
@@ -1,0 +1,78 @@
+use crate::config::ExtraOpts;
+
+use anyhow::{bail, Context, Result};
+
+use prometheus::core::Number;
+use serde_json::Value;
+
+pub(crate) fn bridged_balance<N: Number>(addr: &str, opts: &Option<ExtraOpts>) -> Result<N> {
+    let (handler_addr, token_addr) = match opts {
+        Some(ExtraOpts::BridgedBalance {
+            erc20handler_address,
+            token_address,
+        }) => (erc20handler_address, token_address),
+        _ => {
+            bail!("bridged_balance expecting extra_opts: erc20handler_address and token_address")
+        }
+    };
+
+    let data: Value = ureq::post(addr)
+        .send_json(ureq::json!({
+            "method":"eth_call",
+            "jsonrpc":"2.0",
+            "id":0,
+            "params":[
+                {
+                    // keccak256("balanceOf(address)")[:8] = "70a08231"
+                    // https://eips.ethereum.org/EIPS/eip-20#balanceOf
+                    //
+                    // 0x + function signature(8) + padding(erc20Handler)(64)
+                    "data":format!("0x70a08231{:0>64}", handler_addr.trim_start_matches("0x")),
+                    "to":token_addr
+                },
+                "latest"
+            ],
+        }))
+        .context("bridged_balance requesting balanceOf ureq call failed")?
+        .into_json()
+        .context("bridged_balance requesting balanceOf ureq json failed")?;
+
+    let balance = &data["result"];
+    if balance.is_null() {
+        bail!("bridged_balance the balance is null")
+    }
+
+    let balance = match balance.as_str() {
+        Some(v) => {
+            let mut b = v.trim_start_matches("0x");
+            if b.is_empty() {
+                b = "0"
+            };
+            i64::from_str_radix(b, 16)
+                .with_context(|| format!("balance parse hex failed: {}", v))?
+        }
+        None => bail!(
+            "bridged_balance the balance result is not a str: {}",
+            balance
+        ),
+    };
+
+    Ok(N::from_i64(balance))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bridged_balance() {
+        assert!(bridged_balance::<u64>(
+            "https://prod-testnet.prod.findora.org:8545",
+            &Some(ExtraOpts::BridgedBalance {
+                erc20handler_address: "0xe2b65e624bBb5513fF805d225258D7A92b0f62C4".to_string(),
+                token_address: "0x6ce8da28e2f864420840cf74474eff5fd80e65b8".to_string(),
+            }),
+        )
+        .is_ok())
+    }
+}

--- a/src/tasks/bridged_balance.rs
+++ b/src/tasks/bridged_balance.rs
@@ -12,7 +12,10 @@ pub(crate) fn bridged_balance<N: Number>(addr: &str, opts: &Option<ExtraOpts>) -
             token_address,
         }) => (erc20handler_address, token_address),
         _ => {
-            bail!("bridged_balance expecting extra_opts: erc20handler_address and token_address")
+            bail!(
+                "expecting extra_opts: erc20handler_address and token_address, addr:{:?}",
+                addr
+            )
         }
     };
 
@@ -33,13 +36,23 @@ pub(crate) fn bridged_balance<N: Number>(addr: &str, opts: &Option<ExtraOpts>) -
                 "latest"
             ],
         }))
-        .context("bridged_balance requesting balanceOf ureq call failed")?
+        .with_context(|| {
+            format!(
+                "requesting balanceOf ureq call failed, addr:{:?}, opts:{:?}",
+                addr, opts
+            )
+        })?
         .into_json()
-        .context("bridged_balance requesting balanceOf ureq json failed")?;
+        .with_context(|| {
+            format!(
+                "requesting balanceOf ureq json failed, addr:{:?}, opts:{:?}",
+                addr, opts
+            )
+        })?;
 
     let balance = &data["result"];
     if balance.is_null() {
-        bail!("bridged_balance the balance is null")
+        bail!("the balance is null, addr:{:?}, opts:{:?}", addr, opts)
     }
 
     let balance = match balance.as_str() {
@@ -48,12 +61,18 @@ pub(crate) fn bridged_balance<N: Number>(addr: &str, opts: &Option<ExtraOpts>) -
             if b.is_empty() {
                 b = "0"
             };
-            i64::from_str_radix(b, 16)
-                .with_context(|| format!("balance parse hex failed: {}", v))?
+            i64::from_str_radix(b, 16).with_context(|| {
+                format!(
+                    "balance parse hex failed: {}, addr:{:?}, opts:{:?}",
+                    v, addr, opts
+                )
+            })?
         }
         None => bail!(
-            "bridged_balance the balance result is not a str: {}",
-            balance
+            "the balance result is not a str: {}, addr:{:?}, opts:{:?}",
+            balance,
+            addr,
+            opts
         ),
     };
 

--- a/src/tasks/consensus_power.rs
+++ b/src/tasks/consensus_power.rs
@@ -7,34 +7,39 @@ use serde_json::Value;
 pub(crate) fn consensus_power<N: Number>(addr: &str, _opts: &Option<ExtraOpts>) -> Result<N> {
     let data: Value = ureq::get(&format!("{}/dump_consensus_state", addr))
         .call()
-        .context("get_consensus_power ureq call failed")?
+        .with_context(|| format!("ureq call failed, addr:{:?}", addr))?
         .into_json()
-        .context("get_consensus_power ureq json failed")?;
+        .with_context(|| format!("ureq json failed, addr:{:?}", addr))?;
 
     let power = &data["result"]["round_state"]["last_commit"]["votes_bit_array"];
     if power.is_null() {
-        bail!("power is null")
+        bail!("power is null, addr:{:?}", addr)
     }
 
     let power = match power.as_str() {
         Some(v) => v.to_string(),
-        None => bail!("power is not a str"),
+        None => bail!("power is not a str, addr:{:?}", addr),
     };
 
     let power = match power.rfind('=') {
         Some(pos) => {
             let n = power.len();
             if pos + 2 >= n - 1 {
-                bail!("power cannot be parsed, pos:{}, n:{}", pos, n)
+                bail!(
+                    "power cannot be parsed, pos:{}, n:{}, addr:{:?}",
+                    pos,
+                    n,
+                    addr
+                )
             }
             (&power[pos + 2..n - 1]).to_string()
         }
-        None => bail!("power cannot find = symbol"),
+        None => bail!("power cannot find = symbol, addr:{:?}", addr),
     };
 
     let power: f64 = power
         .parse()
-        .with_context(|| format!("power:{} convert to f64 failed", power))?;
+        .with_context(|| format!("power:{} convert to f64 failed, addr:{:?}", power, addr))?;
 
     Ok(N::from_i64((power * 100.0f64) as i64))
 }

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -8,3 +8,5 @@ mod total_balance_of_relayers;
 pub(crate) use total_balance_of_relayers::total_balance_of_relayers;
 mod bridged_balance;
 pub(crate) use bridged_balance::bridged_balance;
+mod bridged_supply;
+pub(crate) use bridged_supply::bridged_supply;

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -6,3 +6,5 @@ mod total_count_of_validators;
 pub(crate) use total_count_of_validators::total_count_of_validators;
 mod total_balance_of_relayers;
 pub(crate) use total_balance_of_relayers::total_balance_of_relayers;
+mod bridged_balance;
+pub(crate) use bridged_balance::bridged_balance;

--- a/src/tasks/network_functional.rs
+++ b/src/tasks/network_functional.rs
@@ -8,23 +8,23 @@ use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 pub(crate) fn network_functional<N: Number>(addr: &str, _opts: &Option<ExtraOpts>) -> Result<N> {
     let data: Value = ureq::get(&format!("{}/status", addr))
         .call()
-        .context("get_network_functional ureq call failed")?
+        .with_context(|| format!("ureq call failed, addr:{:?}", addr))?
         .into_json()
-        .context("get_network_functional ureq json failed")?;
+        .with_context(|| format!("ureq json failed, addr:{:?}", addr))?;
 
     let latest_block_time = &data["result"]["sync_info"]["latest_block_time"];
     if latest_block_time.is_null() {
-        bail!("latest_block_time is null")
+        bail!("latest_block_time is null, addr:{:?}", addr)
     }
 
     // format is like 2022-01-14T13:44:55.889015796Z UTC time
     let latest_block_time = match latest_block_time.as_str() {
         Some(v) => v,
-        None => bail!("latest_block_time is not a str"),
+        None => bail!("latest_block_time is not a str, addr:{:?}", addr),
     };
 
     let latest_block_timestamp = OffsetDateTime::parse(latest_block_time, &Rfc3339)
-        .context("parse latest_block_time failed")?
+        .with_context(|| format!("parse latest_block_time failed, addr:{:?}", addr))?
         .unix_timestamp();
     let cur_timestamp = OffsetDateTime::now_utc().unix_timestamp();
 

--- a/src/tasks/total_balance_of_relayers.rs
+++ b/src/tasks/total_balance_of_relayers.rs
@@ -9,14 +9,12 @@ pub(crate) fn total_balance_of_relayers<N: Number>(
     addr: &str,
     opts: &Option<ExtraOpts>,
 ) -> Result<N> {
-    // asking the bridge for the count of relayers
     let bridge_addr = match opts {
-        Some(o) => {
-            let ExtraOpts::BridgeAddress(b) = o;
-            b
-        }
-        None => bail!("get_relayer_balance cannot get bridge address"),
+        Some(ExtraOpts::TotalBalanceOfRelayers { bridge_address }) => bridge_address,
+        _ => bail!("total_balance_of_relayers expecting extra_opts: bridge_address"),
     };
+
+    // asking the bridge for the count of relayers
     let data: Value = ureq::post(addr)
         .send_json(ureq::json!({
             "method":"eth_call",
@@ -26,26 +24,28 @@ pub(crate) fn total_balance_of_relayers<N: Number>(
                 {
                     // keccak256("_totalRelayers()")[:8] = "0x802aabe8"
                     // https://github.com/ChainSafe/chainbridge-solidity/blob/master/contracts/Bridge.sol#L314
+                    //
+                    // no params so only function signature
                     "data":"0x802aabe8",
                     "to":bridge_addr
                 },
                 "latest"
             ],
         }))
-        .context("get_relayer_balance ask relayer count ureq call failed")?
+        .context("total_balance_of_relayers ask relayer count ureq call failed")?
         .into_json()
-        .context("get_relayer_balance ask relayer count ureq json failed")?;
+        .context("total_balance_of_relayers ask relayer count ureq json failed")?;
 
     let count = &data["result"];
     if count.is_null() {
-        bail!("get_relayer_balance the relayer count is null")
+        bail!("total_balance_of_relayers the relayer count is null")
     }
 
     let count = match count.as_str() {
         Some(v) => usize::from_str_radix(v.trim_start_matches("0x"), 16)
             .with_context(|| format!("count parse hex failed: {}", v))?,
         None => bail!(
-            "get_relayer_balance the relayer count is not a str: {}",
+            "total_balance_of_relayers the relayer count is not a str: {}",
             count
         ),
     };
@@ -61,8 +61,11 @@ pub(crate) fn total_balance_of_relayers<N: Number>(
                 {
                     // keccak256("getRoleMember(bytes32,uint256)")[:8] = "9010d07c"
                     // https://github.com/ChainSafe/chainbridge-solidity/blob/master/contracts/utils/AccessControl.sol#L104
+                    //
                     // keccak256("RELAYER_ROLE") = "e2b7fb3b832174769106daebcfd6d1970523240dda11281102db9363b83b0dc4"
                     // https://github.com/ChainSafe/chainbridge-solidity/blob/master/contracts/Bridge.sol#L73
+                    //
+                    // function signature(8) + padding(RELAYER_ROLE)(64) + padding(index)(64)
                     "data":format!(
                         "0x9010d07ce2b7fb3b832174769106daebcfd6d1970523240dda11281102db9363b83b0dc4{:064x}", i), 
                     "to":bridge_addr
@@ -74,24 +77,30 @@ pub(crate) fn total_balance_of_relayers<N: Number>(
 
     let data: Value = ureq::post(addr)
         .send_json(serde_json::Value::Array(reqs))
-        .context("get_relayer_balance ask relayer addresses ureq call failed")?
+        .context("total_balance_of_relayers ask relayer addresses ureq call failed")?
         .into_json()
-        .context("get_relayer_balance ask relayer addresses ureq json failed")?;
+        .context("total_balance_of_relayers ask relayer addresses ureq json failed")?;
 
     let data = data
         .as_array()
-        .context("get_relayer_balance ask relayer addresses as_array failed")?;
+        .context("total_balance_of_relayers ask relayer addresses as_array failed")?;
 
     let mut relayers = vec![];
     for d in data {
         let relayer = &d["result"];
         if relayer.is_null() {
-            bail!("get_relayer_balance the relayer result is null: {}", d)
+            bail!(
+                "total_balance_of_relayers the relayer result is null: {}",
+                d
+            )
         }
 
         let relayer = match relayer.as_str() {
             Some(v) => format!("0x{}", v.trim_start_matches("0x").trim_start_matches('0')),
-            None => bail!("get_relayer_balance the relayer result is not a str: {}", d),
+            None => bail!(
+                "total_balance_of_relayers the relayer result is not a str: {}",
+                d
+            ),
         };
 
         relayers.push(relayer);
@@ -113,25 +122,31 @@ pub(crate) fn total_balance_of_relayers<N: Number>(
 
     let data: Value = ureq::post(addr)
         .send_json(serde_json::Value::Array(reqs))
-        .context("get_relayer_balance ask relayer balances ureq call failed")?
+        .context("total_balance_of_relayers ask relayer balances ureq call failed")?
         .into_json()
-        .context("get_relayer_balance ask relayer balances ureq json failed")?;
+        .context("total_balance_of_relayers ask relayer balances ureq json failed")?;
 
     let data = data
         .as_array()
-        .context("get_relayer_balance ask relayer balances as_array failed")?;
+        .context("total_balance_of_relayers ask relayer balances as_array failed")?;
 
     let mut balances: i64 = 0;
     for d in data {
         let balance = &d["result"];
         if balance.is_null() {
-            bail!("get_relayer_balance the balance result is null: {}", d)
+            bail!(
+                "total_balance_of_relayers the balance result is null: {}",
+                d
+            )
         }
 
         let balance = match balance.as_str() {
             Some(v) => u128::from_str_radix(v.trim_start_matches("0x"), 16)
                 .with_context(|| format!("balance parse hex failed: {}", v))?,
-            None => bail!("get_relayer_balance the balance result is not a str: {}", d),
+            None => bail!(
+                "total_balance_of_relayers the balance result is not a str: {}",
+                d
+            ),
         };
 
         // the balance came from relayer is like below:
@@ -155,9 +170,9 @@ mod tests {
     fn test_task_total_balance_of_relayers() {
         assert!(total_balance_of_relayers::<u64>(
             "https://data-seed-prebsc-1-s1.binance.org:8545",
-            &Some(ExtraOpts::BridgeAddress(
-                "0xD609931ec1c7a7F6ad59A69fede03fB067Af997c".to_string()
-            ))
+            &Some(ExtraOpts::TotalBalanceOfRelayers {
+                bridge_address: "0xD609931ec1c7a7F6ad59A69fede03fB067Af997c".to_string(),
+            }),
         )
         .is_ok())
     }

--- a/src/tasks/total_balance_of_relayers.rs
+++ b/src/tasks/total_balance_of_relayers.rs
@@ -11,7 +11,7 @@ pub(crate) fn total_balance_of_relayers<N: Number>(
 ) -> Result<N> {
     let bridge_addr = match opts {
         Some(ExtraOpts::TotalBalanceOfRelayers { bridge_address }) => bridge_address,
-        _ => bail!("total_balance_of_relayers expecting extra_opts: bridge_address"),
+        _ => bail!("expecting extra_opts: bridge_address, addr:{:?}", addr),
     };
 
     // asking the bridge for the count of relayers
@@ -32,21 +32,41 @@ pub(crate) fn total_balance_of_relayers<N: Number>(
                 "latest"
             ],
         }))
-        .context("total_balance_of_relayers ask relayer count ureq call failed")?
+        .with_context(|| {
+            format!(
+                "ask relayer count ureq call failed, addr:{:?}, opts:{:?}",
+                addr, opts
+            )
+        })?
         .into_json()
-        .context("total_balance_of_relayers ask relayer count ureq json failed")?;
+        .with_context(|| {
+            format!(
+                "ask relayer count ureq json failed, addr:{:?}, opts:{:?}",
+                addr, opts
+            )
+        })?;
 
     let count = &data["result"];
     if count.is_null() {
-        bail!("total_balance_of_relayers the relayer count is null")
+        bail!(
+            "the relayer count is null, addr:{:?}, opts:{:?}",
+            addr,
+            opts
+        )
     }
 
     let count = match count.as_str() {
-        Some(v) => usize::from_str_radix(v.trim_start_matches("0x"), 16)
-            .with_context(|| format!("count parse hex failed: {}", v))?,
+        Some(v) => usize::from_str_radix(v.trim_start_matches("0x"), 16).with_context(|| {
+            format!(
+                "count parse hex failed: {}, addr:{:?}, opts:{:?}",
+                v, addr, opts
+            )
+        })?,
         None => bail!(
-            "total_balance_of_relayers the relayer count is not a str: {}",
-            count
+            "the relayer count is not a str: {}, addr:{:?}, opts:{:?}",
+            count,
+            addr,
+            opts
         ),
     };
 
@@ -77,29 +97,46 @@ pub(crate) fn total_balance_of_relayers<N: Number>(
 
     let data: Value = ureq::post(addr)
         .send_json(serde_json::Value::Array(reqs))
-        .context("total_balance_of_relayers ask relayer addresses ureq call failed")?
+        .with_context(|| {
+            format!(
+                "ask relayer addresses ureq call failed, addr:{:?}, opts:{:?}",
+                addr, opts
+            )
+        })?
         .into_json()
-        .context("total_balance_of_relayers ask relayer addresses ureq json failed")?;
+        .with_context(|| {
+            format!(
+                "ask relayer addresses ureq json failed, addr:{:?}, opts:{:?}",
+                addr, opts
+            )
+        })?;
 
-    let data = data
-        .as_array()
-        .context("total_balance_of_relayers ask relayer addresses as_array failed")?;
+    let data = data.as_array().with_context(|| {
+        format!(
+            "ask relayer addresses as_array failed, addr:{:?}, opts:{:?}",
+            addr, opts
+        )
+    })?;
 
     let mut relayers = vec![];
     for d in data {
         let relayer = &d["result"];
         if relayer.is_null() {
             bail!(
-                "total_balance_of_relayers the relayer result is null: {}",
-                d
+                "the relayer result is null: {}, addr:{:?}, opts:{:?}",
+                d,
+                addr,
+                opts
             )
         }
 
         let relayer = match relayer.as_str() {
             Some(v) => format!("0x{}", v.trim_start_matches("0x").trim_start_matches('0')),
             None => bail!(
-                "total_balance_of_relayers the relayer result is not a str: {}",
-                d
+                "the relayer result is not a str: {}, addr:{:?}, opts:{:?}",
+                d,
+                addr,
+                opts
             ),
         };
 
@@ -122,30 +159,51 @@ pub(crate) fn total_balance_of_relayers<N: Number>(
 
     let data: Value = ureq::post(addr)
         .send_json(serde_json::Value::Array(reqs))
-        .context("total_balance_of_relayers ask relayer balances ureq call failed")?
+        .with_context(|| {
+            format!(
+                "ask relayer balances ureq call failed, addr:{:?}, opts:{:?}",
+                addr, opts
+            )
+        })?
         .into_json()
-        .context("total_balance_of_relayers ask relayer balances ureq json failed")?;
+        .with_context(|| {
+            format!(
+                "ask relayer balances ureq json failed, addr:{:?}, opts:{:?}",
+                addr, opts
+            )
+        })?;
 
-    let data = data
-        .as_array()
-        .context("total_balance_of_relayers ask relayer balances as_array failed")?;
+    let data = data.as_array().with_context(|| {
+        format!(
+            "ask relayer balances as_array failed, addr:{:?}, opts:{:?}",
+            addr, opts
+        )
+    })?;
 
     let mut balances: i64 = 0;
     for d in data {
         let balance = &d["result"];
         if balance.is_null() {
             bail!(
-                "total_balance_of_relayers the balance result is null: {}",
-                d
+                "the balance result is null: {}, addr:{:?}, opts:{:?}",
+                d,
+                addr,
+                opts
             )
         }
 
         let balance = match balance.as_str() {
-            Some(v) => u128::from_str_radix(v.trim_start_matches("0x"), 16)
-                .with_context(|| format!("balance parse hex failed: {}", v))?,
+            Some(v) => u128::from_str_radix(v.trim_start_matches("0x"), 16).with_context(|| {
+                format!(
+                    "balance parse hex failed: {}, addr:{:?}, opts:{:?}",
+                    v, addr, opts
+                )
+            })?,
             None => bail!(
-                "total_balance_of_relayers the balance result is not a str: {}",
-                d
+                "the balance result is not a str: {}, addr:{:?}, opts:{:?}",
+                d,
+                addr,
+                opts
             ),
         };
 

--- a/src/tasks/total_count_of_validators.rs
+++ b/src/tasks/total_count_of_validators.rs
@@ -11,24 +11,24 @@ pub(crate) fn total_count_of_validators<N: Number>(
 ) -> Result<N> {
     let data: Value = ureq::get(&format!("{}/validators", addr))
         .call()
-        .context("get_total_validators ureq call failed")?
+        .with_context(|| format!("ureq call failed, addr:{:?}", addr))?
         .into_json()
-        .context("get_total_validators ureq json failed")?;
+        .with_context(|| format!("ureq json failed, addr:{:?}", addr))?;
 
     let total_validators = &data["result"]["total"];
     if total_validators.is_null() {
-        bail!("total_validators is null")
+        bail!("total_validators is null, addr:{:?}", addr)
     }
 
     let total_validators = match total_validators.as_str() {
         Some(v) => v.to_string(),
-        None => bail!("total_validators is not a str"),
+        None => bail!("total_validators is not a str, addr:{:?}", addr),
     };
 
     let total_validators: i64 = total_validators.parse().with_context(|| {
         format!(
-            "total_validators:{} convert to i64 failed",
-            total_validators
+            "total_validators:{} convert to i64 failed, addr:{:?}",
+            total_validators, addr,
         )
     })?;
 


### PR DESCRIPTION
#### adding two new metrics
1. BridgedBalance 
    - the token balance of reserving safe on source chain 
    - ( this metric displays with 8 digits as the fractional part so need to divide the metric value by 10 to the power of 8 )
2. BridgedSupply
    - the token supply total minted on the destination chain 
    - ( this metric displays with 8 digits as the fractional part so need to divide the metric value by 10 to the power of 8 )

#### enhancing debugging log
let it be more clear and identical

#### adjusting action workflow to use cache
avg CI time from 2m30s to 1m30s

#### enhancing documentation
describing more detail about how to use keccak256 with the simple POST method without any library to achieve the metrics crawling goal